### PR TITLE
Feature/restart button

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-06-20T10:06:10.477312Z">
+        <DropdownSelection timestamp="2025-07-15T12:56:41.392866Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/remziakgoz/.android/avd/Pixel_9.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/remziakgoz/.android/avd/Pixel_6a.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/src/main/java/com/remziakgoz/coffeepomodoro/presentation/components/RestartButton.kt
+++ b/app/src/main/java/com/remziakgoz/coffeepomodoro/presentation/components/RestartButton.kt
@@ -1,0 +1,32 @@
+package com.remziakgoz.coffeepomodoro.presentation.components
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun RestartButton(modifier: Modifier = Modifier, onClick: () -> Unit) {
+    FilledIconButton(
+        onClick = onClick,
+        modifier = modifier.size(50.dp),
+        shape = CircleShape,
+        colors = IconButtonDefaults.filledIconButtonColors(
+            containerColor = Color.White.copy(alpha = 0.15f),
+            contentColor = Color.White.copy(alpha = 0.9f)
+        )
+    ) {
+        Icon(
+            imageVector = Icons.Default.Refresh,
+            contentDescription = "Restart",
+            modifier = Modifier.size(24.dp)
+        )
+    }
+} 

--- a/app/src/main/java/com/remziakgoz/coffeepomodoro/presentation/components/RestartButton.kt
+++ b/app/src/main/java/com/remziakgoz/coffeepomodoro/presentation/components/RestartButton.kt
@@ -1,32 +1,94 @@
 package com.remziakgoz.coffeepomodoro.presentation.components
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun RestartButton(modifier: Modifier = Modifier, onClick: () -> Unit) {
-    FilledIconButton(
-        onClick = onClick,
-        modifier = modifier.size(50.dp),
-        shape = CircleShape,
-        colors = IconButtonDefaults.filledIconButtonColors(
-            containerColor = Color.White.copy(alpha = 0.15f),
-            contentColor = Color.White.copy(alpha = 0.9f)
-        )
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.92f else 1f,
+        animationSpec = tween(durationMillis = 100),
+        label = "buttonScale"
+    )
+    
+    Box(
+        modifier = modifier.size(52.dp),
+        contentAlignment = Alignment.Center
     ) {
-        Icon(
-            imageVector = Icons.Default.Refresh,
-            contentDescription = "Restart",
-            modifier = Modifier.size(24.dp)
+        // Glow effect background
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .scale(scale)
+                .clip(CircleShape)
+                .background(
+                    Color.White.copy(alpha = 0.3f)
+                )
+                .blur(8.dp)
         )
+        
+        // Main button with glassmorphism
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .scale(scale)
+                .clip(CircleShape)
+                .background(
+                    brush = Brush.radialGradient(
+                        colors = listOf(
+                            Color.White.copy(alpha = 0.25f),
+                            Color.White.copy(alpha = 0.1f)
+                        )
+                    )
+                )
+                .border(
+                    width = 1.5.dp,
+                    brush = Brush.verticalGradient(
+                        colors = listOf(
+                            Color.White.copy(alpha = 0.6f),
+                            Color.White.copy(alpha = 0.2f)
+                        )
+                    ),
+                    shape = CircleShape
+                )
+                .clickable(
+                    interactionSource = interactionSource,
+                    indication = null,
+                    onClick = onClick
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Default.Refresh,
+                contentDescription = "Restart",
+                tint = Color.White.copy(alpha = 0.95f),
+                modifier = Modifier.size(22.dp)
+            )
+        }
     }
 } 

--- a/app/src/main/java/com/remziakgoz/coffeepomodoro/presentation/pomodoro/PomodoroViewModel.kt
+++ b/app/src/main/java/com/remziakgoz/coffeepomodoro/presentation/pomodoro/PomodoroViewModel.kt
@@ -332,6 +332,63 @@ class PomodoroViewModel : ViewModel() {
         }
     }
 
+    fun restart() {
+        // Cancel any running timers and animations
+        timerJob?.cancel()
+        animationJob?.cancel()
+        
+        // Reset current session based on state, but keep cycle count
+        when (_uiState.value.currentState) {
+            PomodoroState.Work, PomodoroState.Paused -> {
+                // Reset to work state with full pomodoro time
+                _uiState.value = _uiState.value.copy(
+                    currentState = PomodoroState.Ready,
+                    remainingTime = pomodoroTime,
+                    isRunning = false,
+                    animationProgress = 1f,
+                    pausedTime = 0L,
+                    pausedTimeReverse = 0L
+                    // Keep cycleCount unchanged
+                )
+            }
+            PomodoroState.ShortBreak -> {
+                // Reset to short break with full break time
+                _uiState.value = _uiState.value.copy(
+                    currentState = PomodoroState.ShortBreak,
+                    remainingTime = breakTime,
+                    isRunning = false,
+                    animationProgress = 0f,
+                    pausedTime = 0L,
+                    pausedTimeReverse = 0L
+                    // Keep cycleCount unchanged
+                )
+            }
+            PomodoroState.LongBreak -> {
+                // Reset to long break with full break time
+                _uiState.value = _uiState.value.copy(
+                    currentState = PomodoroState.LongBreak,
+                    remainingTime = longBreakTime,
+                    isRunning = false,
+                    animationProgress = 0f,
+                    pausedTime = 0L,
+                    pausedTimeReverse = 0L
+                    // Keep cycleCount unchanged
+                )
+            }
+            PomodoroState.Ready -> {
+                // Already in ready state, just ensure everything is reset
+                _uiState.value = _uiState.value.copy(
+                    remainingTime = pomodoroTime,
+                    isRunning = false,
+                    animationProgress = 1f,
+                    pausedTime = 0L,
+                    pausedTimeReverse = 0L
+                    // Keep cycleCount unchanged
+                )
+            }
+        }
+    }
+
     override fun onCleared() {
         super.onCleared()
         timerJob?.cancel()

--- a/app/src/main/java/com/remziakgoz/coffeepomodoro/presentation/pomodoro/views/PomodoroScreen.kt
+++ b/app/src/main/java/com/remziakgoz/coffeepomodoro/presentation/pomodoro/views/PomodoroScreen.kt
@@ -1,13 +1,17 @@
 package com.remziakgoz.coffeepomodoro.presentation.pomodoro.views
 
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -21,6 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -31,6 +36,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.remziakgoz.coffeepomodoro.presentation.components.CoffeeAnimation
 import com.remziakgoz.coffeepomodoro.presentation.components.CoffeeCoreButton
 import com.remziakgoz.coffeepomodoro.presentation.components.PomodoroWithCanvasClock
+import com.remziakgoz.coffeepomodoro.presentation.components.RestartButton
 import com.remziakgoz.coffeepomodoro.presentation.components.StartButton
 import com.remziakgoz.coffeepomodoro.presentation.pomodoro.PomodoroState
 import com.remziakgoz.coffeepomodoro.presentation.pomodoro.PomodoroViewModel
@@ -92,6 +98,13 @@ fun PomodoroScreen(
         label = "bottomColor"
     )
 
+    // Animate restart button visibility
+    val restartButtonAlpha by animateFloatAsState(
+        targetValue = if (uiState.value.currentState != PomodoroState.Ready) 1f else 0f,
+        animationSpec = tween(durationMillis = 300),
+        label = "restartButtonAlpha"
+    )
+
     // Create gradient background
     val gradientBrush = Brush.verticalGradient(
         colors = listOf(topColor, bottomColor),
@@ -112,21 +125,37 @@ fun PomodoroScreen(
         ) {
             Spacer(modifier = modifier.padding(top = 20.dp))
             
-            // iPhone notch-style cycle indicator
+            // Top bar with centered cycle indicator and positioned restart button
             Box(
                 modifier = Modifier
-                    .clip(RoundedCornerShape(20.dp))
-                    .background(
-                        Color.Black.copy(alpha = 0.7f)
-                    )
-                    .padding(horizontal = 20.dp, vertical = 8.dp),
-                contentAlignment = Alignment.Center
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp)
             ) {
-                Text(
-                    text = "Cycle: ${uiState.value.cycleCount}/4",
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.Medium,
-                    color = Color.White
+                // iPhone notch-style cycle indicator - always centered
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .clip(RoundedCornerShape(20.dp))
+                        .background(
+                            Color.Black.copy(alpha = 0.7f)
+                        )
+                        .padding(horizontal = 20.dp, vertical = 8.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "Cycle: ${uiState.value.cycleCount}/4",
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Medium,
+                        color = Color.White
+                    )
+                }
+                
+                // Restart button in top right - absolute positioning
+                RestartButton(
+                    modifier = Modifier
+                        .align(Alignment.CenterEnd)
+                        .alpha(restartButtonAlpha),
+                    onClick = { viewModel.restart() }
                 )
             }
             


### PR DESCRIPTION
### 🆕 Added
- Restart button component to allow users to reset the Pomodoro timer manually

### ✨ Improved
- UI design of the restart button to match retro flip clock aesthetic
- Button animation and placement for better UX

### 🧪 Tested
- Manual reset functionality during active and paused timer states
- Restart works correctly with animation transitions

---
This PR introduces a new restart feature that improves overall usability and aligns with the timer's visual theme.