### PR TITLE
fix: Prevent multiple rapid clicks on all interactive buttons

### DIFF
--- a/app/src/main/java/com/remziakgoz/coffeepomodoro/presentation/components/CoffeeCoreButton.kt
+++ b/app/src/main/java/com/remziakgoz/coffeepomodoro/presentation/components/CoffeeCoreButton.kt
@@ -21,6 +21,9 @@ fun CoffeeCoreButton(modifier: Modifier = Modifier, onClick: () -> Unit) {
     val composition by rememberLottieComposition(LottieCompositionSpec.Asset("coffeeTurned.json"))
     val animatable = rememberLottieAnimatable()
     var lastClickTime by remember { mutableLongStateOf(0L) }
+    
+    // Debounce delay in milliseconds
+    val debounceDelay = 1000L // 1 second
 
     LaunchedEffect(lastClickTime) {
         if (lastClickTime > 0 && composition != null) {
@@ -39,8 +42,14 @@ fun CoffeeCoreButton(modifier: Modifier = Modifier, onClick: () -> Unit) {
                 interactionSource = remember { MutableInteractionSource() },
                 indication = null
             ) {
-                lastClickTime = System.currentTimeMillis()
-                onClick()
+                val currentTime = System.currentTimeMillis()
+                
+                // Only process click if enough time has passed since last click
+                if (currentTime - lastClickTime >= debounceDelay) {
+                    lastClickTime = currentTime
+                    onClick()
+                }
+                // Ignore rapid successive clicks
             }
     )
 }

--- a/app/src/main/java/com/remziakgoz/coffeepomodoro/presentation/components/NextStepButton.kt
+++ b/app/src/main/java/com/remziakgoz/coffeepomodoro/presentation/components/NextStepButton.kt
@@ -15,7 +15,9 @@ import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
@@ -31,12 +33,13 @@ import com.remziakgoz.coffeepomodoro.R
 
 @Composable
 fun NextStepButton(
-    modifier: Modifier = Modifier,
+    modifier: Modifier = Modifier, 
     onClick: () -> Unit
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
-
+    var lastClickTime by remember { mutableLongStateOf(0L) }
+    
     val scale by animateFloatAsState(
         targetValue = if (isPressed) 0.92f else 1f,
         animationSpec = tween(durationMillis = 100),
@@ -86,7 +89,15 @@ fun NextStepButton(
                 .clickable(
                     interactionSource = interactionSource,
                     indication = null,
-                    onClick = onClick
+                    onClick = {
+                        val currentTime = System.currentTimeMillis()
+                        // Debounce with 500ms delay to prevent rapid clicks
+                        if (currentTime - lastClickTime >= 500L) {
+                            lastClickTime = currentTime
+                            onClick()
+                        }
+                        // Ignore rapid successive clicks
+                    }
                 ),
             contentAlignment = Alignment.Center
         ) {

--- a/app/src/main/java/com/remziakgoz/coffeepomodoro/presentation/components/RestartButton.kt
+++ b/app/src/main/java/com/remziakgoz/coffeepomodoro/presentation/components/RestartButton.kt
@@ -15,7 +15,9 @@ import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
@@ -29,6 +31,7 @@ import androidx.compose.ui.unit.dp
 fun RestartButton(modifier: Modifier = Modifier, onClick: () -> Unit) {
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
+    var lastClickTime by remember { mutableLongStateOf(0L) }
     
     val scale by animateFloatAsState(
         targetValue = if (isPressed) 0.92f else 1f,
@@ -79,7 +82,15 @@ fun RestartButton(modifier: Modifier = Modifier, onClick: () -> Unit) {
                 .clickable(
                     interactionSource = interactionSource,
                     indication = null,
-                    onClick = onClick
+                    onClick = {
+                        val currentTime = System.currentTimeMillis()
+                        // Debounce with 500ms delay to prevent rapid clicks
+                        if (currentTime - lastClickTime >= 500L) {
+                            lastClickTime = currentTime
+                            onClick()
+                        }
+                        // Ignore rapid successive clicks
+                    }
                 ),
             contentAlignment = Alignment.Center
         ) {

--- a/app/src/main/java/com/remziakgoz/coffeepomodoro/presentation/components/StartButton.kt
+++ b/app/src/main/java/com/remziakgoz/coffeepomodoro/presentation/components/StartButton.kt
@@ -80,10 +80,12 @@ fun StartButton(
                 indication = null
             ) { 
                 val currentTime = System.currentTimeMillis()
-                if (currentTime - lastClickTime >= 300L && !isAnimating) {
+                // Debounce with 800ms delay to prevent rapid clicks
+                if (currentTime - lastClickTime >= 800L && !isAnimating) {
                     onClick()
                     lastClickTime = currentTime
                 }
+                // Ignore rapid successive clicks
             }
     )
 }


### PR DESCRIPTION
## 🐛 Problem
Users could rapidly click buttons (especially the break screen coffee button) causing app instability and unexpected behavior.

## ✅ Solution
Added click debouncing to prevent rapid successive clicks on all interactive buttons:

- **CoffeeCoreButton** (Break screen): 1000ms debounce delay
- **StartButton** (Play/Pause): 800ms debounce delay  
- **NextStepButton** (Skip navigation): 500ms debounce delay
- **RestartButton** (Reset): 500ms debounce delay

## 🛡️ How it works
- First click: Processed normally
- Rapid successive clicks: Ignored until debounce period expires
- Visual feedback: Button animations continue working
- User experience: Seamless, users won't notice the protection

## 🎯 Benefits
- Prevents app crashes from button spam
- Maintains responsive UI feel
- Protects all interactive elements
- Improves overall stability

## 🧪 Testing
Test by rapidly clicking any button - only the first click should register until the debounce period expires.